### PR TITLE
Pass completion also to the sink

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const takeUntil = sSrc => src => (start, sink) => {
       } else if (st === 1) {
         talkback(2);
         sTalkback(2);
+        sink(2);
         done = true;
       }
       !done && sink(t, d);


### PR DESCRIPTION
Because termination should not be mutual we need to explicitly pass completion value (2) to the sink, otherwise it won't ever be notified about it.

I might add test for this later.