### PR TITLE
Cover more termination cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,19 +9,22 @@ const takeUntil = sSrc => src => (start, sink) => {
       sourceTalkback = d;
 
       sSrc(0, (st, sd) => {
+        if (done) return;
+
         if (st === 0) {
           sTalkback = sd;
           sTalkback(1);
-        } else if (st === 1) {
-          sourceTalkback(2);
-          sTalkback(2);
-          inited && sink(2);
-          done = true;
+          return
         }
+        done = true;
+        sourceTalkback(2);
+        sTalkback(2);
+        inited && sink(2);
       });
 
+      inited = true;
+
       sink(0, (st, sd) => {
-        inited = true;
         st === 2 && sTalkback(2);
         !done && sourceTalkback(st, sd);
       });

--- a/index.js
+++ b/index.js
@@ -1,22 +1,37 @@
 const takeUntil = sSrc => src => (start, sink) => {
-  let talkback, sTalkback;
+  if (start !== 0) return;
+  let sourceTalkback, sTalkback;
+  let inited = false;
   let done = false;
-  start === 0 && src(start, (t, d) => {
-    if (t === start) {
-      talkback = d;
+
+  src(0, (t, d) => {
+    if (t === 0) {
+      sourceTalkback = d;
+
+      sSrc(0, (st, sd) => {
+        if (st === 0) {
+          sTalkback = sd;
+          sTalkback(1);
+        } else if (st === 1) {
+          sourceTalkback(2);
+          sTalkback(2);
+          inited && sink(2);
+          done = true;
+        }
+      });
+
+      sink(0, (st, sd) => {
+        inited = true;
+        st === 2 && sTalkback(2);
+        !done && sourceTalkback(st, sd);
+      });
+
+      done && sink(2);
+      return;
     }
-    sSrc(start, (st, sd) => {
-      if (st === start) {
-        sTalkback = sd;
-        sTalkback(1);
-      } else if (st === 1) {
-        talkback(2);
-        sTalkback(2);
-        sink(2);
-        done = true;
-      }
-      !done && sink(t, d);
-    });
+
+    t === 2 && sTalkback(2);
+    !done && sink(t, d);
   });
 };
 

--- a/test.js
+++ b/test.js
@@ -63,7 +63,7 @@ test('it stops from a pullable source', function (t) {
 });
 
 test('it stops an async listenable source', function (t) {
-  t.plan(16);
+  t.plan(18);
   const upwardsExpected = [
     [0, 'function'],
     [2, 'undefined']
@@ -166,6 +166,65 @@ test('it returns a source that disposes upon upwards END (2)', function (t) {
   }
 
   takeUntil(newBagFromPromise(400))(makeSource())(0, makeSink());
+
+  setTimeout(() => {
+    t.pass('Nothing else happens');
+    t.end();
+  }, 400);
+});
+
+test('it notifies the sink about termination', function (t) {
+  t.plan(18);
+  const upwardsExpected = [
+    [0, 'function'],
+    [2, 'undefined']
+  ];
+  const downwardsExpectedType = [
+    [0, 'function'],
+    [1, 'number'],
+    [1, 'number'],
+    [1, 'number'],
+    [2, 'undefined'],
+  ];
+  const downwardsExpected = [10, 20, 30];
+
+  function makeSource() {
+    let sent = 0;
+    let id;
+    const source = (type, data) => {
+      const e = upwardsExpected.shift();
+      t.equals(type, e[0], 'upwards type is expected: ' + e[0]);
+      t.equals(typeof data, e[1], 'upwards data is expected: ' + e[1]);
+      if (type === 0) {
+        const sink = data;
+        id = setInterval(() => {
+          sink(1, ++sent * 10);
+        }, 100);
+        sink(0, source);
+      } else if (type === 2) {
+        clearInterval(id);
+      }
+    };
+    return source;
+  }
+
+  function makeSink() {
+    let talkback;
+    return (type, data) => {
+      const et = downwardsExpectedType.shift();
+      t.equals(type, et[0], 'downwards type is expected: ' + et[0]);
+      t.equals(typeof data, et[1], 'downwards data type is expected: ' + et[1]);
+      if (type === 0) {
+        talkback = data;
+      }
+      if (type === 1) {
+        const e = downwardsExpected.shift();
+        t.equals(data, e, 'downwards data is expected: ' + e);
+      }
+    };
+  }
+
+  takeUntil(newBagFromPromise(350))(makeSource())(0, makeSink());
 
   setTimeout(() => {
     t.pass('Nothing else happens');

--- a/test.js
+++ b/test.js
@@ -148,7 +148,7 @@ test('it returns a source that disposes upon upwards END (2)', function (t) {
     return source;
   }
 
-  function makeSink(type, data) {
+  function makeSink() {
     let talkback;
     return (type, data) => {
       const et = downwardsExpectedType.shift();


### PR DESCRIPTION
I've started from wanting to provide a test for #1 and when doing so I've noticed several problems with the actual implementation and while fixing it I've also encountered some "edge cases" that I had to fix too.

1. `sSrc` was subscribed **each time** `src` has emitted **anything**
2. `sink` was notified (`sink(t, d)`) from `sSrc` callbag, while it should be notified from `src` callbag
3. upward termination (done by `sink`) was just passed to the source, while it should also be handled internally by `takeUntil` and passed upwards afterwards
