### PR TITLE
Fix case with empty notifier - sink should not get terminated

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ const takeUntil = notifier => source => (start, sink) => {
         }
         if (t === 2) {
           notifierTalkback = null;
-          done = d;
           if (d != null) {
+            done = d;
             sourceTalkback(2);
             if (inited) sink(t, d);
           }
@@ -46,8 +46,8 @@ const takeUntil = notifier => source => (start, sink) => {
       return;
     }
 
-    if (type === 2) notifierTalkback(2);
-    if (done === UNIQUE) sink(type, data);
+    if (type === 2 && notifierTalkback) notifierTalkback(2);
+    sink(type, data);
   });
 };
 

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ pipe(
       console.log('value', v);
     },
     complete() {
-      console.log('done'); // logs "done" but does not clear the interval!
+      console.log('done'); // won't ever be called
     }
   })
 );


### PR DESCRIPTION
If we want to comply to Rx semantics this has been a bug: https://github.com/ReactiveX/rxjs/blob/2979ec168855a18cece695652a83f8f5af1a9437/spec/operators/takeUntil-spec.ts#L33 

When "fixing" this I've realized lately that at least part of the former behavior was intentional on your part since: https://github.com/franciscotln/callbag-take-until/commit/67b17b3b77f0f0720fed2e6475037be274b793eb , but I don't believe that chosen behavior was good. For instance, it was not possible to unsubscribe from the source in certain situations and this should always be possible.